### PR TITLE
Add support for passing the user_agent parameter per request

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -1,6 +1,10 @@
 Version History
 ===============
 
+`1.0.4`_ May 12, 2017
+---------------------
+- Add support for passing the user_agent parameter per request
+
 `1.0.3`_ Apr 28, 2017
 ---------------------
 - Fix the installer
@@ -17,6 +21,8 @@ Version History
 ---------------------
 - Initial Version
 
+.. _1.0.4: https://github.com/sprockets/sprockets.amqp/compare/1.0.3...1.0.4
+.. _1.0.3: https://github.com/sprockets/sprockets.amqp/compare/1.0.2...1.0.3
 .. _1.0.2: https://github.com/sprockets/sprockets.amqp/compare/1.0.1...1.0.2
 .. _1.0.1: https://github.com/sprockets/sprockets.amqp/compare/1.0.0...1.0.1
 .. _1.0.0: https://github.com/sprockets/sprockets.amqp/compare/2fc5bad...1.0.0

--- a/sprockets/mixins/http/__init__.py
+++ b/sprockets/mixins/http/__init__.py
@@ -15,7 +15,7 @@ from ietfparse import algorithms, errors, headers
 from tornado import gen, httpclient
 import umsgpack
 
-__version__ = '1.0.3'
+__version__ = '1.0.4'
 
 LOGGER = logging.getLogger(__name__)
 
@@ -65,7 +65,8 @@ class HTTPClientMixin(object):
                    connect_timeout=DEFAULT_CONNECT_TIMEOUT,
                    request_timeout=DEFAULT_REQUEST_TIMEOUT,
                    auth_username=None,
-                   auth_password=None):
+                   auth_password=None,
+                   user_agent=None):
         """Perform a HTTP request
 
         Will retry up to ``self.MAX_HTTP_RETRIES`` times.
@@ -85,6 +86,8 @@ class HTTPClientMixin(object):
             default 20 seconds
         :param str auth_username: Username for HTTP authentication
         :param str auth_password: Password for HTTP authentication
+        :param str user_agent: The str used for the ``User-Agent`` header,
+            default used if unspecified.
         :rtype: HTTPResponse
 
         """
@@ -109,7 +112,7 @@ class HTTPClientMixin(object):
                     auth_password=auth_password,
                     connect_timeout=connect_timeout,
                     request_timeout=request_timeout,
-                    user_agent=self._http_req_user_agent(),
+                    user_agent=user_agent or self._http_req_user_agent(),
                     follow_redirects=follow_redirects,
                     raise_error=False)
             except (OSError, socket.gaierror) as error:

--- a/tests.py
+++ b/tests.py
@@ -218,6 +218,23 @@ class MixinTestCase(testing.AsyncHTTPTestCase):
                              {'foo': ['bar'], 'status_code': ['200']})
 
     @testing.gen_test()
+    def test_get_custom_user_agent(self):
+        response = yield self.mixin.http_fetch(
+            self.get_url('/test?foo=bar&status_code=200'),
+            request_headers={'Accept': 'application/json'},
+            user_agent='custom/3.0.0')
+
+        self.assertTrue(response.ok)
+        self.assertEqual(response.code, 200)
+        self.assertEqual(response.body['headers'].get('Correlation-Id'),
+                         self.correlation_id)
+        self.assertEqual(response.attempts, 1)
+        self.assertEqual(
+            response.body['headers'].get('User-Agent'), 'custom/3.0.0')
+        self.assertDictEqual(response.body['args'],
+                             {'foo': ['bar'], 'status_code': ['200']})
+
+    @testing.gen_test()
     def test_post_html(self):
         expectation = '<html>foo</html>'
         response = yield self.mixin.http_fetch(
@@ -251,6 +268,26 @@ class MixinTestCase(testing.AsyncHTTPTestCase):
         self.assertEqual(response.attempts, 1)
         self.assertEqual(
             response.body['headers'].get('User-Agent'), 'test/0.1.0')
+        self.assertDictEqual(response.body['body'],
+                             {'foo': 'bar', 'status_code': 200})
+
+    @testing.gen_test()
+    def test_post_custom_user_agent(self):
+        response = yield self.mixin.http_fetch(
+            self.get_url('/test'),
+            method='POST',
+            body={'foo': 'bar', 'status_code': 200},
+            request_headers={'Accept': 'application/json',
+                             'Content-Type': 'application/json'},
+            user_agent='custom/3.0.0')
+
+        self.assertTrue(response.ok)
+        self.assertEqual(response.code, 200)
+        self.assertEqual(response.body['headers'].get('Correlation-Id'),
+                         self.correlation_id)
+        self.assertEqual(response.attempts, 1)
+        self.assertEqual(
+            response.body['headers'].get('User-Agent'), 'custom/3.0.0')
         self.assertDictEqual(response.body['body'],
                              {'foo': 'bar', 'status_code': 200})
 


### PR DESCRIPTION
This allows overriding the default user_agent used for the httpclient fetch request. Also bump version to 1.0.4