### PR TITLE
Expose additional tornado request features.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -84,6 +84,15 @@ As with Tornado, to use the curl client which has numerous benefits:
        app.listen(8000)
        ioloop.IOLoop.current().start()
 
+Environment Variables
+---------------------
+
++------------------+----------------------------------------------------------+
+| HTTP_MAX_CLIENTS | An optional setting that specifies the maximum number of |
+|                  | simultaneous asynchronous HTTP requests. If not          |
+|                  | specified, the default Tornado value of 10 will be used. |
++------------------+----------------------------------------------------------+
+
 License
 -------
 ``sprockets.mixins.http`` is released under the `3-Clause BSD license <https://github.com/sprockets/sprockets.mixins.http/blob/master/LICENSE>`_.

--- a/sprockets/mixins/http/__init__.py
+++ b/sprockets/mixins/http/__init__.py
@@ -23,7 +23,6 @@ LOGGER = logging.getLogger(__name__)
 CONTENT_TYPE_JSON = headers.parse_content_type('application/json')
 CONTENT_TYPE_MSGPACK = headers.parse_content_type('application/msgpack')
 DEFAULT_USER_AGENT = 'sprockets.mixins.http/{}'.format(__version__)
-DEFAULT_MAX_CLIENTS = 10
 
 
 HTTPResponse = collections.namedtuple(

--- a/sprockets/mixins/http/__init__.py
+++ b/sprockets/mixins/http/__init__.py
@@ -66,7 +66,8 @@ class HTTPClientMixin(object):
                    request_timeout=DEFAULT_REQUEST_TIMEOUT,
                    auth_username=None,
                    auth_password=None,
-                   user_agent=None):
+                   user_agent=None,
+                   allow_nonstandard_methods=False):
         """Perform a HTTP request
 
         Will retry up to ``self.MAX_HTTP_RETRIES`` times.
@@ -88,6 +89,8 @@ class HTTPClientMixin(object):
         :param str auth_password: Password for HTTP authentication
         :param str user_agent: The str used for the ``User-Agent`` header,
             default used if unspecified.
+        :param bool allow_nonstardard_methods: Allow methods that don't adhere
+            to the HTTP spec.
         :rtype: HTTPResponse
 
         """
@@ -114,7 +117,8 @@ class HTTPClientMixin(object):
                     request_timeout=request_timeout,
                     user_agent=user_agent or self._http_req_user_agent(),
                     follow_redirects=follow_redirects,
-                    raise_error=False)
+                    raise_error=False,
+                    allow_nonstandard_methods=allow_nonstandard_methods)
             except (OSError, socket.gaierror) as error:
                 LOGGER.debug('HTTP Request Error for %s to %s'
                              'attempt %i of %i: %s',

--- a/tests.py
+++ b/tests.py
@@ -1,8 +1,9 @@
 import json
 import logging
+import os
 import uuid
 
-from tornado import httputil, testing, web
+from tornado import httpclient, httputil, testing, web
 import mock
 import umsgpack
 
@@ -400,6 +401,15 @@ class MixinTestCase(testing.AsyncHTTPTestCase):
             method='DELETE',
             body={'foo': 'bar', 'status_code': 200},
             allow_nonstandard_methods=True)
-
         self.assertTrue(response.ok)
-        self.assertEqual(response.code, 200)
+
+    @testing.gen_test()
+    def test_max_clients_settings_supported(self):
+        os.environ['HTTP_MAX_CLIENTS'] = '25'
+        response = yield self.mixin.http_fetch(
+            self.get_url('/test?foo=bar&status_code=200'))
+        self.assertTrue(response.ok)
+        del os.environ['HTTP_MAX_CLIENTS']
+        client = httpclient.AsyncHTTPClient()
+        self.assertEqual(client.max_clients, 25)
+

--- a/tests.py
+++ b/tests.py
@@ -393,4 +393,13 @@ class MixinTestCase(testing.AsyncHTTPTestCase):
         self.assertEqual(response.headers['Content-Type'], 'text/html')
         self.assertEqual(response.body.decode('utf-8'), expectation)
 
+    @testing.gen_test()
+    def test_allow_nonstardard_methods(self):
+        response = yield self.mixin.http_fetch(
+            self.get_url('/test'),
+            method='DELETE',
+            body={'foo': 'bar', 'status_code': 200},
+            allow_nonstandard_methods=True)
 
+        self.assertTrue(response.ok)
+        self.assertEqual(response.code, 200)


### PR DESCRIPTION
This PR exposes two more options when making request with Tornado's AsyncHTTPClient.
1) Expose the allow_nonstandard_methods option on requests.
2) Allow the max_clients setting to be set on the HTTP connections.

max_clients is being set in an unorthodox manner to handle cases where the the client connection cache has been instantiated outside of this mixin.