### PR TITLE
Make retries configurable

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -1,6 +1,10 @@
 Version History
 ===============
 
+`1.0.6`_ Aug 16, 2017
+---------------------
+- Add ``max_http_attempts`` keyword param
+
 `1.0.5`_ Aug 7, 2017
 --------------------
 - Add support for allow_nonstandard_methods and max_clients
@@ -25,6 +29,7 @@ Version History
 ---------------------
 - Initial Version
 
+.. _1.0.6: https://github.com/sprockets/sprockets.mixins.http/compare/1.0.5...1.0.6
 .. _1.0.5: https://github.com/sprockets/sprockets.mixins.http/compare/1.0.4...1.0.5
 .. _1.0.4: https://github.com/sprockets/sprockets.mixins.http/compare/1.0.3...1.0.4
 .. _1.0.3: https://github.com/sprockets/sprockets.mixins.http/compare/1.0.2...1.0.3

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ def read_requirements(name):
 
 setuptools.setup(
     name='sprockets.mixins.http',
-    version='1.0.5',
+    version='1.0.6',
     description='HTTP Client Mixin for Tornado RequestHandlers',
     long_description=open('README.rst').read(),
     url='https://github.com/sprockets/sprockets.mixins.http',

--- a/sprockets/mixins/http/__init__.py
+++ b/sprockets/mixins/http/__init__.py
@@ -16,7 +16,7 @@ from ietfparse import algorithms, errors, headers
 from tornado import gen, httpclient
 import umsgpack
 
-__version__ = '1.0.4'
+__version__ = '1.0.6'
 
 LOGGER = logging.getLogger(__name__)
 

--- a/sprockets/mixins/http/__init__.py
+++ b/sprockets/mixins/http/__init__.py
@@ -65,6 +65,7 @@ class HTTPClientMixin(object):
                    follow_redirects=False,
                    connect_timeout=DEFAULT_CONNECT_TIMEOUT,
                    request_timeout=DEFAULT_REQUEST_TIMEOUT,
+                   max_http_attempts=MAX_HTTP_RETRIES,
                    auth_username=None,
                    auth_password=None,
                    user_agent=None,
@@ -86,6 +87,8 @@ class HTTPClientMixin(object):
             seconds, default 20 seconds
         :param float request_timeout:  Timeout for entire request in seconds,
             default 20 seconds
+        :param int max_http_attempts: Maximum number of times to retry
+            a request, default is 3 attempts
         :param str auth_username: Username for HTTP authentication
         :param str auth_password: Password for HTTP authentication
         :param str user_agent: The str used for the ``User-Agent`` header,
@@ -108,9 +111,9 @@ class HTTPClientMixin(object):
             client.max_clients = int(os.getenv('HTTP_MAX_CLIENTS'))
 
         response, start_time = None, time.time()
-        for attempt in range(0, self.MAX_HTTP_RETRIES):
+        for attempt in range(0, max_http_attempts):
             LOGGER.debug('%s %s (Attempt %i of %i) %r',
-                         method, url, attempt, self.MAX_HTTP_RETRIES,
+                         method, url, attempt + 1, max_http_attempts,
                          request_headers)
             try:
                 response = yield client.fetch(


### PR DESCRIPTION
The number of attempts was only exposed as an attribute.  This PR exposes it as a keyword parameter that defaults to the class attribute.

We might want to get away from the usage of class attributes for default parameters because it can have some rather amusing and unexpected behaviors:
```python
class MyHandler(http.HTTPClientMixin, web.RequestHandler):

    DEFAULT_CONNECT_TIMEOUT = 1
    DEFAULT_REQUEST_TIMEOUT = 5

    def initialize(self):
        super(MyHandler, self).initialize()
        self.logger = logging.getLogger('MyHandler')

    @gen.coroutine
    def get(self):
        rsp = yield self.http_fetch('http://httpbin.org/delay/15')
        self.logger.info('response %r', rsp)
        self.set_status(204)
```

Calls will succeed in about 11 seconds because the "defaults" are evaluated at compile time of `HTTPClientMixin.http_request` and done in the context of `HTTPClientMixin`.  IOW - redefining them is actually quite useless.  Makes sense when you think about it but probably not what everyone would expect.