### PR TITLE
Deserialize option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,6 +31,15 @@ Requirements
 - `tornado <https://tornadoweb.org>`_ >=4.2.0,<5
 - `u-msgpack-python <http://u-msgpack-python.readthedocs.io/en/latest/>`_ >=2.1,<3
 
+Contributing
+------------
+.. code:: bash
+
+    $ python3.5 -m venv env
+    $ source env/bin/activate
+    (env) $ env/bin/pip install -r requires/testing.txt -i https://pypi.python.org/simple
+    (env) $ env/bin/nosetests -xvs tests.py
+
 Example
 -------
 

--- a/tests.py
+++ b/tests.py
@@ -236,6 +236,21 @@ class MixinTestCase(testing.AsyncHTTPTestCase):
                              {'foo': ['bar'], 'status_code': ['200']})
 
     @testing.gen_test()
+    def test_deserialize_option_set_false(self):
+        expectation = '{"data": "abcd123"}'
+        response = yield self.mixin.http_fetch(
+                self.get_url('/test?content_type=application/json'),
+                method='POST',
+                body={'response': expectation},
+                request_headers={'Accept': 'application/json'},
+                deserialize=False)
+
+        self.assertTrue(response.ok)
+        self.assertEqual(response.code, 200)
+        self.assertEqual(response.attempts, 1)
+        self.assertEqual(response.body.decode('utf-8'), expectation)
+
+    @testing.gen_test()
     def test_post_html(self):
         expectation = '<html>foo</html>'
         response = yield self.mixin.http_fetch(


### PR DESCRIPTION
Ran into an instance where sprockets ability to deserialize base on filetype became problematic when trying to insert into Postgres. 
Scenario:
- Main service was making request using http_fetch to another service that was setting the Content-Type to 'application/json' based on file type. 
- If the file type was .json, Sprockets.mixins.http would then see the content-type and decode it to json and send that back to the main service.
- Main service would take response and try to insert it into the database and would error because it was a dict

Could of just serialized it back into what was expected/would have worked to INSERT into the database. But thought since this was a mixin, having the option to not always deserialize the data in the body of the response would be beneficial in some cases.
