### PR TITLE
Fix content type

### DIFF
--- a/sprockets/mixins/http/__init__.py
+++ b/sprockets/mixins/http/__init__.py
@@ -278,6 +278,8 @@ class HTTPClientMixin(object):
         """
         if not response.body:
             return None
+        if 'Content-Type' not in response.headers:
+            return response.body
         try:
             content_type = algorithms.select_content_type(
                 [headers.parse_content_type(response.headers['Content-Type'])],

--- a/tests.py
+++ b/tests.py
@@ -2,6 +2,8 @@ import io
 import json
 import logging
 import os
+import sys
+import unittest
 import uuid
 
 from tornado import httpclient, httputil, testing, web
@@ -415,6 +417,8 @@ class MixinTestCase(testing.AsyncHTTPTestCase):
         self.assertEqual(client.max_clients, 25)
 
     @testing.gen_test()
+    @unittest.skipUnless(sys.version_info >= (3, ),
+                         'StringIO requires Python 3')
     def test_missing_content_type(self):
         # Craft a response that lacks a Content-Type header.
         request = httpclient.HTTPRequest(

--- a/tests.py
+++ b/tests.py
@@ -1,3 +1,4 @@
+import io
 import json
 import logging
 import os
@@ -413,3 +414,16 @@ class MixinTestCase(testing.AsyncHTTPTestCase):
         client = httpclient.AsyncHTTPClient()
         self.assertEqual(client.max_clients, 25)
 
+    @testing.gen_test()
+    def test_missing_content_type(self):
+        # Craft a response that lacks a Content-Type header.
+        request = httpclient.HTTPRequest(
+            self.get_url('/test?foo=bar&status_code=200'))
+        response = httpclient.HTTPResponse(
+            request, code=200, headers={},
+            buffer=io.StringIO('Do not try to deserialize me.'))
+        # Try to deserialize that response. It should not raise an exception.
+        try:
+            response_body = self.mixin._http_resp_deserialize(response)
+        except KeyError:
+            self.fail('http_fetch raised KeyError!')


### PR DESCRIPTION
When a response's headers lack Content-Type, the _http_resp_deserialize() raised a KeyError. This PR fixes that bug.

This scenario happened in the field with a web server that I do not own. The server runs Microsoft Internet Information Services (IIS) 7.5 circa 2009. Although I cannot control that web server, their content, or what content my clients want to use; I can handle it more gracefully here.