### PR TITLE
Multiple client improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ install:
 - pip install -r requires/development.txt
 script:
 - nosetests
+- flake8
 after_success:
 - codecov
 - ./setup.py build_sphinx

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -1,6 +1,17 @@
 Version History
 ===============
 
+`1.2.0`_ Apr 1, 2019
+--------------------
+- Add ``history`` attribute of the response with all response objects
+- Add ``links`` attribute of the response with the parsed link header if set
+- Change logging level in a few places to a more appropriate level
+- Add support for rejected consumers when auto-creating the ``User-Agent`` header
+- Add the netloc of a request to the log entry created when rate limited
+- Use RequestHandler.settings instead of RequestHandler.application.settings
+  when auto-creating the ``User-Agent`` header for a Tornado request handler
+- Add test coverage of the Warning response header behavior
+
 `1.1.1`_ Jan 9, 2019
 --------------------
 - Fix failure when response lacks Content-Type header

--- a/requires/testing.txt
+++ b/requires/testing.txt
@@ -1,5 +1,13 @@
 coverage>3,<5
 codecov
-mock
+flake8
+flake8-comprehensions
+flake8-deprecated
+flake8-html
+flake8-import-order
+flake8-quotes
+flake8-rst-docstrings
+flake8-tuple
 nose>=1.3.1,<2.0.0
+sprockets.mixins.mediatype>=3.0.0
 -r installation.txt

--- a/requires/testing.txt
+++ b/requires/testing.txt
@@ -10,4 +10,5 @@ flake8-rst-docstrings
 flake8-tuple
 nose>=1.3.1,<2.0.0
 sprockets.mixins.mediatype>=3.0.0
+u-msgpack-python
 -r installation.txt

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,11 @@
 [bdist_wheel]
 universal = 1
 
+[flake8]
+application-import-names=sprockets.mixins.http
+exclude=build,env
+import-order-style=google
+
 [nosetests]
 cover-branches=1
 cover-erase=1

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,8 +2,8 @@
 universal = 1
 
 [flake8]
-application-import-names=sprockets.mixins.http
-exclude=build,env
+application-import-names=sprockets.mixins
+exclude=build,docs,env
 import-order-style=google
 
 [nosetests]

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,8 +2,9 @@
 universal = 1
 
 [flake8]
-application-import-names=sprockets.mixins
+application-import-names=sprockets.mixins.http
 exclude=build,docs,env
+ignore=RST304
 import-order-style=google
 
 [nosetests]

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ def read_requirements(name):
 
 setuptools.setup(
     name='sprockets.mixins.http',
-    version='1.1.1',
+    version='1.2.0',
     description='HTTP Client Mixin for Tornado RequestHandlers',
     long_description=open('README.rst').read(),
     url='https://github.com/sprockets/sprockets.mixins.http',
@@ -31,8 +31,10 @@ setuptools.setup(
     author_email='api@aweber.com',
     license='BSD',
     classifiers=[
-        'Development Status :: 3 - Alpha', 'Intended Audience :: Developers',
-        'License :: OSI Approved :: BSD License', 'Natural Language :: English',
+        'Development Status :: 4 - Beta',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: BSD License',
+        'Natural Language :: English',
         'Operating System :: OS Independent',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: Implementation :: CPython',

--- a/sprockets/mixins/http/__init__.py
+++ b/sprockets/mixins/http/__init__.py
@@ -53,9 +53,10 @@ slightly higher level of functionality than Tornado's
 
 
 class HTTPClientMixin:
-    """Mixin for making http requests. Requests using the asynchronous
-    :meth:`HTTPClientMixin.http_fetch` method """
+    """Mixin for making http requests using the asynchronous
+    :py:meth:`~sprockets.mixins.http.HTTPClientMixin.http_fetch` method.
 
+    """
     AVAILABLE_CONTENT_TYPES = [CONTENT_TYPE_JSON, CONTENT_TYPE_MSGPACK]
 
     DEFAULT_CONNECT_TIMEOUT = 10
@@ -94,8 +95,8 @@ class HTTPClientMixin:
         :param mixed body: The HTTP request body to send with the request
         :param content_type: The mime type to use for requests & responses.
             Defaults to ``application/msgpack``
-        :type content_type: :class:`~ietfparse.datastructures.ContentType` or
-            str
+        :type content_type: :py:class:`~ietfparse.datastructures.ContentType`
+            or str
         :param bool follow_redirects: Follow HTTP redirects when received
         :param int max_redirects: Maximum number of redirects to follow,
             default is 5
@@ -172,10 +173,10 @@ class HTTPClientMixin:
 
             if 200 <= response.code < 400:
                 return HTTPResponse(
-                        True, response.code, dict(response.headers),
-                        self._http_resp_deserialize(response),
-                        response, attempt + 1, time.time() - start_time,
-                        links, history)
+                    True, response.code, dict(response.headers),
+                    self._http_resp_deserialize(response),
+                    response, attempt + 1, time.time() - start_time,
+                    links, history)
             elif response.code in {423, 429}:
                 await self._http_resp_rate_limited(response)
             elif 400 <= response.code < 500:
@@ -185,9 +186,9 @@ class HTTPClientMixin:
                              method, url, response.code, attempt + 1,
                              max_http_attempts, error)
                 return HTTPResponse(
-                        False, response.code, dict(response.headers),
-                        error, response, attempt + 1,
-                        time.time() - start_time, links, history)
+                    False, response.code, dict(response.headers),
+                    error, response, attempt + 1,
+                    time.time() - start_time, links, history)
             else:
                 LOGGER.warning(
                     'HTTP Response Error for %s to %s, '
@@ -199,13 +200,13 @@ class HTTPClientMixin:
                        max_http_attempts)
         if response:
             return HTTPResponse(
-                    False, response.code, dict(response.headers),
-                    self._http_resp_error_message(response) or response.body,
-                    response, max_http_attempts,
-                    time.time() - start_time, links, history)
-        return HTTPResponse(
-                False, 599, None, None, None, max_http_attempts,
+                False, response.code, dict(response.headers),
+                self._http_resp_error_message(response) or response.body,
+                response, max_http_attempts,
                 time.time() - start_time, links, history)
+        return HTTPResponse(
+            False, 599, None, None, None, max_http_attempts,
+            time.time() - start_time, links, history)
 
     def _http_req_apply_default_headers(self, request_headers,
                                         content_type, body):

--- a/sprockets/mixins/http/__init__.py
+++ b/sprockets/mixins/http/__init__.py
@@ -16,6 +16,10 @@ from urllib import parse
 from ietfparse import algorithms, errors, headers
 from sprockets.mixins.mediatype import transcoders
 from tornado import httpclient
+try:
+    from tornado.curl_httpclient import CurlError
+except ModuleNotFoundError:
+    CurlError = OSError
 
 __version__ = '1.1.2'
 
@@ -143,7 +147,7 @@ class HTTPClientMixin:
                     raise_error=False,
                     validate_cert=validate_cert,
                     allow_nonstandard_methods=allow_nonstandard_methods)
-            except (OSError, socket.gaierror) as error:
+            except (OSError, socket.gaierror, CurlError) as error:
                 LOGGER.debug('HTTP Request Error for %s to %s'
                              'attempt %i of %i: %s',
                              method, url, attempt + 1,

--- a/sprockets/mixins/http/__init__.py
+++ b/sprockets/mixins/http/__init__.py
@@ -34,9 +34,9 @@ HTTPResponse = collections.namedtuple(
     ['ok', 'code', 'headers', 'body', 'raw', 'attempts', 'duration',
      'links', 'history'])
 """Response in the form of a :class:`~collections.namedtuple` returned from
-:meth:`~sprockets.mixins.http.HTTPClientMixin.http_fetch` that provides a
+:py:meth:`~sprockets.mixins.http.HTTPClientMixin.http_fetch` that provides a
 slightly higher level of functionality than Tornado's
-:class:`tornado.httpclient.HTTPResponse` class.
+:py:class:`tornado.httpclient.HTTPResponse` class.
 
 :param bool ok: The response status code was between 200 and 308
 :param int code: The HTTP response status code
@@ -213,7 +213,7 @@ class HTTPClientMixin:
 
         :param dict request_headers: The HTTP request headers
         :param content_type: The mime-type used in the request/response
-        :type content_type: :class:`ietfparse.datastructures.ContentType`
+        :type content_type: :py:class:`ietfparse.datastructures.ContentType`
             or str
         :param mixed body: The request body
         :rtype: dict
@@ -286,9 +286,8 @@ class HTTPClientMixin:
         if isinstance(value, list):
             return [self._http_resp_decode(v) for v in value]
         elif isinstance(value, dict):
-            return dict([(self._http_resp_decode(k),
-                          self._http_resp_decode(v))
-                         for k, v in value.items()])
+            return {self._http_resp_decode(k): self._http_resp_decode(v)
+                    for k, v in value.items()}
         elif isinstance(value, bytes):
             return value.decode('utf-8')
         return value

--- a/sprockets/mixins/http/__init__.py
+++ b/sprockets/mixins/http/__init__.py
@@ -11,12 +11,13 @@ import logging
 import os
 import socket
 import time
+from urllib import parse
 
 from ietfparse import algorithms, errors, headers
 from sprockets.mixins.mediatype import transcoders
 from tornado import httpclient
 
-__version__ = '1.1.1'
+__version__ = '1.1.2'
 
 LOGGER = logging.getLogger(__name__)
 
@@ -317,6 +318,8 @@ class HTTPClientMixin:
         :rtype: tornado.concurrent.Future
 
         """
+        parsed = parse.urlparse(response.request.url)
         duration = int(response.headers.get('Retry-After', 3))
-        LOGGER.warning('Rate Limited by, retrying in %i seconds', duration)
+        LOGGER.warning('Rate Limited by %s, retrying in %i seconds',
+                       parsed.netloc, duration)
         return asyncio.sleep(duration)

--- a/tests.py
+++ b/tests.py
@@ -3,11 +3,11 @@ import json
 import logging
 import os
 import sys
+from unittest import mock
 import unittest
 import uuid
 
 from tornado import httpclient, httputil, testing, web
-import mock
 import umsgpack
 
 from sprockets.mixins import http
@@ -428,6 +428,6 @@ class MixinTestCase(testing.AsyncHTTPTestCase):
             buffer=io.StringIO('Do not try to deserialize me.'))
         # Try to deserialize that response. It should not raise an exception.
         try:
-            response_body = self.mixin._http_resp_deserialize(response)
+            self.mixin._http_resp_deserialize(response)
         except KeyError:
             self.fail('http_fetch raised KeyError!')

--- a/tests.py
+++ b/tests.py
@@ -5,10 +5,9 @@ import os
 from unittest import mock
 import uuid
 
+from sprockets.mixins import http
 from tornado import httpclient, httputil, testing, web
 import umsgpack
-
-from sprockets.mixins import http
 
 LOGGER = logging.getLogger(__name__)
 

--- a/tests.py
+++ b/tests.py
@@ -22,7 +22,7 @@ def decode(value):
     if isinstance(value, list):
         return [decode(v) for v in value]
     elif isinstance(value, dict):
-        return dict([(decode(k), decode(v)) for k, v in value.items()])
+        return {decode(k): decode(v) for k, v in value.items()}
     elif isinstance(value, bytes):
         return value.decode('utf-8')
     return value
@@ -434,11 +434,11 @@ class MixinTestCase(testing.AsyncHTTPTestCase):
     def test_unsupported_accept(self):
         expectation = '<html>foo</html>'
         response = yield self.mixin.http_fetch(
-                self.get_url('/test?content_type=text/html'),
-                method='POST',
-                body={'response': expectation},
-                request_headers={'Accept': 'text/html',
-                                 'Content-Type': 'application/json'})
+            self.get_url('/test?content_type=text/html'),
+            method='POST',
+            body={'response': expectation},
+            request_headers={'Accept': 'text/html',
+                             'Content-Type': 'application/json'})
         self.assertTrue(response.ok)
         self.assertEqual(response.headers['Content-Type'], 'text/html')
         self.assertEqual(response.body.decode('utf-8'), expectation)


### PR DESCRIPTION
- Add ``history`` attribute of the response with all response objects
- Add ``links`` attribute of the response with the parsed link header if set
- Change logging level in a few places to a more appropriate level
- Add support for rejected consumers when auto-creating the ``User-Agent`` header
- Add the netloc of a request to the log entry created when rate limited
- Use RequestHandler.settings instead of RequestHandler.application.settings
  when auto-creating the ``User-Agent`` header for a Tornado request handler
- Add test coverage of the Warning response header behavior
- Handle CurlError when using pycurl
- Add flake8 tests
- Bump trove-classifier to beta from alpha, really is more stable, but will reserve for next release