### PR TITLE
Fix doc build

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2017 AWeber Communications
+Copyright (c) 2017-2019 AWeber Communications
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,

--- a/README.rst
+++ b/README.rst
@@ -23,7 +23,7 @@ you can install `pycurl <https://pycurl.io>`_ with:
 
 Documentation
 -------------
-https://pythonhosted.org/sprockets.mixins.http/
+https://sprocketsmixinshttp.readthedocs.io
 
 Requirements
 ------------
@@ -104,5 +104,5 @@ License
 .. |CodeCov| image:: https://codecov.io/github/sprockets/sprockets.mixins.http/coverage.svg?branch=master
    :target: https://codecov.io/github/sprockets/sprockets.mixins.http?branch=master
 
-.. |Docs| image:: https://img.shields.io/badge/docs-pythonhosted-green.svg
-   :target: https://pythonhosted.org/sprockets.mixins.http/
+.. |Docs| image:: https://img.shields.io/readthedocs/sprocketsmixinshttp
+   :target: https://sprocketsmixinshttp.readthedocs.io/

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,12 +20,3 @@ intersphinx_mapping = {
     'python': ('https://docs.python.org/', None),
     'tornado': ('https://www.tornadoweb.org/en/stable/', None),
 }
-
-
-def no_namedtuple_attrib_docstring(app, objtype, name, member, keep, options):
-    if objtype == 'class' and name in http.HTTPResponse._fields:
-        return True
-
-
-def setup(app):
-    app.connect('autodoc-skip-member', no_namedtuple_attrib_docstring)

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -1,6 +1,10 @@
 Version History
 ===============
 
+`Next Release
+-------------
+- Fix documentation builds
+
 `2.1.0`_ May 7, 2019
 --------------------
 - Cast the ``url`` parameter of ``http_fetch`` to a string.

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -4,6 +4,7 @@ Version History
 `Next Release
 -------------
 - Fix documentation builds
+- Update documentation links to readthedocs.io
 
 `2.1.0`_ May 7, 2019
 --------------------

--- a/requires/docs.txt
+++ b/requires/docs.txt
@@ -1,2 +1,3 @@
-sphinx-rtd-theme
-sphinxcontrib-httpdomain
+sphinx==2.1.2
+sphinx-rtd-theme==0.4.3
+sphinxcontrib-httpdomain==1.7.0

--- a/requires/testing.txt
+++ b/requires/testing.txt
@@ -1,13 +1,13 @@
-coverage>3,<5
-codecov
-flake8
-flake8-comprehensions
-flake8-deprecated
-flake8-html
-flake8-import-order
-flake8-quotes
-flake8-rst-docstrings
-flake8-tuple
-nose>=1.3.1,<2.0.0
-u-msgpack-python
+coverage==4.5.4
+codecov==2.0.15
+flake8==3.7.8
+flake8-comprehensions==2.1.0
+flake8-deprecated==1.3
+flake8-html==0.4.0
+flake8-import-order==0.18.1
+flake8-quotes==2.1.0
+flake8-rst-docstrings==0.0.10
+flake8-tuple==0.4.0
+nose==1.3.7
+u-msgpack-python==2.5.1
 -r installation.txt


### PR DESCRIPTION
The documentation build has been broken since the refactor in 2.x.  This PR should fix the documentation builds.  I also plan on moving them to readthedocs.io once the docs are building again.  I'll take care of releasing once everything is working again.