### PR TITLE
Remove error response body transformation

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -1,6 +1,11 @@
 Version History
 ===============
 
+Next Release
+------------
+- Remove transformation of response body when response code >= 400 and the
+  deserialized body contains a ``message`` attribute.
+
 `2.2.0`_ Aug 29, 2019
 ---------------------
 - Add handling of ``tornado.httpclient.HTTPTimeoutError`` and

--- a/sprockets/mixins/http/__init__.py
+++ b/sprockets/mixins/http/__init__.py
@@ -94,8 +94,6 @@ class HTTPResponse:
         """
         if not self._responses:
             return None
-        if self._responses[-1].code >= 400:
-            return self._error_message()
         return self._deserialize()
 
     @property
@@ -229,15 +227,6 @@ class HTTPResponse:
         elif content_type[0] == CONTENT_TYPE_MSGPACK:  # pragma: nocover
             return self._decode(
                 self._msgpack.unpackb(self._responses[-1].body))
-
-    def _error_message(self):
-        """Try and extract the error message from a HTTP error response.
-
-        :rtype: str
-
-        """
-        body = self._deserialize()
-        return body.get('message', body) if isinstance(body, dict) else body
 
 
 class HTTPClientMixin:

--- a/tests.py
+++ b/tests.py
@@ -440,7 +440,9 @@ class MixinTestCase(testing.AsyncHTTPTestCase):
         self.assertFalse(response.ok)
         self.assertEqual(response.code, 400)
         self.assertEqual(response.attempts, 1)
-        self.assertEqual(response.body, 'Test Error')
+        self.assertEqual(
+            response.body,
+            {'message': 'Test Error', 'type': 'Test Error', 'traceback': None})
 
     @testing.gen_test
     def test_error_retry(self):


### PR DESCRIPTION
This feature prevents users from accessing other attributes in deserialized error response bodies.