### PR TITLE
Add handling of tornado.httpclient.HTTPError

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -3,6 +3,8 @@ Version History
 
 `Next Release
 -------------
+- Add handling of ``tornado.httpclient.HTTPTimeoutError`` and
+  ``tornado.httpclient.HTTPStreamClosedError`` exceptions
 - Fix documentation builds
 - Update documentation links to readthedocs.io
 

--- a/sprockets/mixins/http/__init__.py
+++ b/sprockets/mixins/http/__init__.py
@@ -9,17 +9,12 @@ import asyncio
 import functools
 import logging
 import os
-import socket
 import time
 from urllib import parse
 
 from ietfparse import algorithms, errors, headers
 from sprockets.mixins.mediatype import transcoders
 from tornado import httpclient
-try:
-    from tornado.curl_httpclient import CurlError
-except ModuleNotFoundError:
-    CurlError = OSError
 
 __version__ = '2.1.0'
 
@@ -352,10 +347,7 @@ class HTTPClientMixin:
                     raise_error=False,
                     validate_cert=validate_cert,
                     allow_nonstandard_methods=allow_nonstandard_methods)
-            except (ConnectionError,
-                    CurlError,
-                    OSError,
-                    socket.gaierror) as error:
+            except (OSError, httpclient.HTTPError) as error:
                 response.append_exception(error)
                 LOGGER.warning(
                     'HTTP Request Error for %s to %s attempt %i of %i: %s',


### PR DESCRIPTION
Only handle OSError and httpclient.HTTPError.
- We can assume any instance of httpclient.HTTPError is a failure
  unrelated to the status code of the response. This is due to
  sprockets.mixins.http setting `raise_error=False` when making the
  request.
- ConnectionError and socket.gaierror are both instances of OSError
- CurlError is an instance of tornado.httpclient.HTTPError
- Other instances of tornado.httpclient.HTTPError include
  HTTPTimeoutError and HTTPStreamClosedError

Also needed to fix the instance assertions in the test. It was always
true as it was evaluating the truthyness of a list - not the isinstance
values.
