### PR TITLE
Fix compile-time setting of default args in http_fetch

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -1,6 +1,10 @@
 Version History
 ===============
 
+`2.2.2`_ Oct 29, 2019
+---------------------
+- Fix compile-time setting of default argument values in ``http_fetch``.
+
 `2.2.1`_ Sep 20, 2019
 ---------------------
 - Remove the lrucache on response body due to a bug in behavior

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ def read_requirements(name):
 
 setuptools.setup(
     name='sprockets.mixins.http',
-    version='2.2.1',
+    version='2.2.2',
     description='HTTP Client Mixin for Tornado RequestHandlers',
     long_description=open('README.rst').read(),
     url='https://github.com/sprockets/sprockets.mixins.http',

--- a/sprockets/mixins/http/__init__.py
+++ b/sprockets/mixins/http/__init__.py
@@ -259,7 +259,7 @@ class HTTPClientMixin:
                          method='GET',
                          request_headers=None,
                          body=None,
-                         content_type=None,
+                         content_type=CONTENT_TYPE_MSGPACK,
                          follow_redirects=False,
                          max_redirects=None,
                          connect_timeout=None,
@@ -314,7 +314,7 @@ class HTTPClientMixin:
         response = HTTPResponse()
 
         request_headers = self._http_req_apply_default_headers(
-            request_headers, content_type or CONTENT_TYPE_MSGPACK, body)
+            request_headers, content_type, body)
 
         if body:
             body = self._http_req_body_serialize(

--- a/sprockets/mixins/http/__init__.py
+++ b/sprockets/mixins/http/__init__.py
@@ -259,12 +259,12 @@ class HTTPClientMixin:
                          method='GET',
                          request_headers=None,
                          body=None,
-                         content_type=CONTENT_TYPE_MSGPACK,
+                         content_type=None,
                          follow_redirects=False,
-                         max_redirects=MAX_REDIRECTS,
-                         connect_timeout=DEFAULT_CONNECT_TIMEOUT,
-                         request_timeout=DEFAULT_REQUEST_TIMEOUT,
-                         max_http_attempts=MAX_HTTP_RETRIES,
+                         max_redirects=None,
+                         connect_timeout=None,
+                         request_timeout=None,
+                         max_http_attempts=None,
                          auth_username=None,
                          auth_password=None,
                          user_agent=None,
@@ -305,10 +305,16 @@ class HTTPClientMixin:
         :rtype: HTTPResponse
 
         """
+        # Apply default values for non-specified arguments
+        max_http_attempts = max_http_attempts or self.MAX_HTTP_RETRIES
+        max_redirects = max_redirects or self.MAX_REDIRECTS
+        connect_timeout = connect_timeout or self.DEFAULT_CONNECT_TIMEOUT
+        request_timeout = request_timeout or self.DEFAULT_REQUEST_TIMEOUT
+
         response = HTTPResponse()
 
         request_headers = self._http_req_apply_default_headers(
-            request_headers, content_type, body)
+            request_headers, content_type or CONTENT_TYPE_MSGPACK, body)
 
         if body:
             body = self._http_req_body_serialize(


### PR DESCRIPTION
Using class level attributes for argument defaults causes default argument values that do not change, if you change the class level attributes.