### PR TITLE
Deprecate error response body transformation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -86,8 +86,8 @@ Error Response Body
 -------------------
 
 For errors, the HTTPResponse object will include a complete body.
-To reduce error response bodies down to just the error message, a class that
-uses this mixin can set ``self.simplify_error_response = True``.
+To reduce error response bodies down to just the error message, users of this
+mixin can set ``self.simplify_error_response = True``.
 
 Environment Variables
 ---------------------

--- a/README.rst
+++ b/README.rst
@@ -85,9 +85,19 @@ As with Tornado, to use the curl client which has numerous benefits:
 Error Response Body
 -------------------
 
-For errors, the HTTPResponse object will include a complete body.
-To reduce error response bodies down to just the error message, users of this
-mixin can set ``self.simplify_error_response = True``.
+For errors, i.e. a response with HTTP status code in the 400 range...
+
+The HTTPResponse object's body is reduced down to just the error message.
+That is this mixin's default behavior.
+
+For a JSON response body with Problem Details (RFC 7807), you may want more
+than just the error message.  To gain access to the complete, deserialized
+response body; a class that uses this mixin can set:
+
+.. code:: python
+
+    ``self.simplify_error_response = False``.
+
 
 Environment Variables
 ---------------------

--- a/README.rst
+++ b/README.rst
@@ -82,6 +82,13 @@ As with Tornado, to use the curl client which has numerous benefits:
        app.listen(8000)
        ioloop.IOLoop.current().start()
 
+Error Response Body
+-------------------
+
+For errors, the HTTPResponse object will include a complete body.
+To reduce error response bodies down to just the error message, a class that
+uses this mixin can set ``self.simplify_error_response = True``.
+
 Environment Variables
 ---------------------
 

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -1,8 +1,8 @@
 Version History
 ===============
 
-Next Release
-------------
+`2.3.0`_ Dec 9, 2019
+--------------------
 - Added an option to control response body transformation for errors, i.e. HTTP
   status code >= 400.  By default, a JSON or otherwise structured response body
   will be reduced down to its error ``message``.  That can be overridden by
@@ -97,6 +97,8 @@ Next Release
 ---------------------
 - Initial Version
 
+.. _2.3.0: https://github.com/sprockets/sprockets.mixins.http/compare/2.2.1...2.3.0
+.. _2.2.1: https://github.com/sprockets/sprockets.mixins.http/compare/2.2.0...2.2.1
 .. _2.2.0: https://github.com/sprockets/sprockets.mixins.http/compare/2.1.0...2.2.0
 .. _2.1.0: https://github.com/sprockets/sprockets.mixins.http/compare/2.0.1...2.1.0
 .. _2.0.1: https://github.com/sprockets/sprockets.mixins.http/compare/2.0.0...2.0.1

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -1,6 +1,12 @@
 Version History
 ===============
 
+Next Release
+------------
+- Deprecated transformation of response body when response code >= 400 and the
+  deserialized body contains a ``message`` attribute.  This can be overridden
+  with the ``simplify_error_response_body`` option.
+
 `2.2.2`_ Oct 29, 2019
 ---------------------
 - Fix compile-time setting of default argument values in ``http_fetch``.

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -5,7 +5,7 @@ Next Release
 ------------
 - Deprecated transformation of response body when response code >= 400 and the
   deserialized body contains a ``message`` attribute.  This can be overridden
-  with the ``simplify_error_response_body`` option.
+  with the ``simplify_error_response`` option.
 
 `2.2.2`_ Oct 29, 2019
 ---------------------

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -3,9 +3,10 @@ Version History
 
 Next Release
 ------------
-- Deprecated transformation of response body when response code >= 400 and the
-  deserialized body contains a ``message`` attribute.  This can be overridden
-  with the ``simplify_error_response`` option.
+- Added an option to control response body transformation for errors, i.e. HTTP
+  status code >= 400.  By default, a JSON or otherwise structured response body
+  will be reduced down to its error ``message``.  That can be overridden by
+  setting ``simplify_error_response`` to False.
 
 `2.2.2`_ Oct 29, 2019
 ---------------------

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ def read_requirements(name):
 
 setuptools.setup(
     name='sprockets.mixins.http',
-    version='2.2.2',
+    version='2.3.0',
     description='HTTP Client Mixin for Tornado RequestHandlers',
     long_description=open('README.rst').read(),
     url='https://github.com/sprockets/sprockets.mixins.http',

--- a/sprockets/mixins/http/__init__.py
+++ b/sprockets/mixins/http/__init__.py
@@ -31,14 +31,14 @@ class HTTPResponse:
 
     """
 
-    def __init__(self, simplify_error_response=False):
+    def __init__(self, simplify_error_response=True):
         self._exceptions = []
         self._finish = None
         self._json = transcoders.JSONTranscoder()
         self._msgpack = transcoders.MsgPackTranscoder()
         self._responses = []
         self._start = time.time()
-        self._simplify_error_response = simplify_error_response or False
+        self._simplify_error_response = simplify_error_response
 
     def __len__(self):
         """Return the length of the exception stack and response stack.
@@ -255,7 +255,7 @@ class HTTPClientMixin:
         super().__init__(*args, **kwargs)
         self.__hcm_json = transcoders.JSONTranscoder()
         self.__hcm_msgpack = transcoders.MsgPackTranscoder()
-        self.simplify_error_response = False
+        self.simplify_error_response = True
 
     async def http_fetch(self, url,
                          method='GET',

--- a/sprockets/mixins/http/__init__.py
+++ b/sprockets/mixins/http/__init__.py
@@ -255,7 +255,7 @@ class HTTPClientMixin:
         super().__init__(*args, **kwargs)
         self.__hcm_json = transcoders.JSONTranscoder()
         self.__hcm_msgpack = transcoders.MsgPackTranscoder()
-        self.settings['simplify_error_response'] = False
+        self.simplify_error_response = False
 
     async def http_fetch(self, url,
                          method='GET',
@@ -313,7 +313,7 @@ class HTTPClientMixin:
         connect_timeout = connect_timeout or self.DEFAULT_CONNECT_TIMEOUT
         request_timeout = request_timeout or self.DEFAULT_REQUEST_TIMEOUT
 
-        response = HTTPResponse(simplify_error_response=self.settings['simplify_error_response'])
+        response = HTTPResponse(simplify_error_response=self.simplify_error_response)
 
         request_headers = self._http_req_apply_default_headers(
             request_headers, content_type, body)

--- a/sprockets/mixins/http/__init__.py
+++ b/sprockets/mixins/http/__init__.py
@@ -313,7 +313,8 @@ class HTTPClientMixin:
         connect_timeout = connect_timeout or self.DEFAULT_CONNECT_TIMEOUT
         request_timeout = request_timeout or self.DEFAULT_REQUEST_TIMEOUT
 
-        response = HTTPResponse(simplify_error_response=self.simplify_error_response)
+        response = HTTPResponse(
+            simplify_error_response=self.simplify_error_response)
 
         request_headers = self._http_req_apply_default_headers(
             request_headers, content_type, body)

--- a/sprockets/mixins/http/__init__.py
+++ b/sprockets/mixins/http/__init__.py
@@ -15,7 +15,7 @@ from ietfparse import algorithms, errors, headers
 from sprockets.mixins.mediatype import transcoders
 from tornado import httpclient
 
-__version__ = '2.2.1'
+__version__ = '2.3.0'
 
 LOGGER = logging.getLogger(__name__)
 

--- a/sprockets/mixins/http/__init__.py
+++ b/sprockets/mixins/http/__init__.py
@@ -31,13 +31,14 @@ class HTTPResponse:
 
     """
 
-    def __init__(self):
+    def __init__(self, simplify_error_response=False):
         self._exceptions = []
         self._finish = None
         self._json = transcoders.JSONTranscoder()
         self._msgpack = transcoders.MsgPackTranscoder()
         self._responses = []
         self._start = time.time()
+        self._simplify_error_response = simplify_error_response or False
 
     def __len__(self):
         """Return the length of the exception stack and response stack.
@@ -92,7 +93,7 @@ class HTTPResponse:
         """
         if not self._responses:
             return None
-        if self._responses[-1].code >= 400:
+        if self._responses[-1].code >= 400 and self._simplify_error_response:
             return self._error_message()
         return self._deserialize()
 
@@ -254,6 +255,7 @@ class HTTPClientMixin:
         super().__init__(*args, **kwargs)
         self.__hcm_json = transcoders.JSONTranscoder()
         self.__hcm_msgpack = transcoders.MsgPackTranscoder()
+        self.settings['simplify_error_response'] = False
 
     async def http_fetch(self, url,
                          method='GET',
@@ -311,7 +313,7 @@ class HTTPClientMixin:
         connect_timeout = connect_timeout or self.DEFAULT_CONNECT_TIMEOUT
         request_timeout = request_timeout or self.DEFAULT_REQUEST_TIMEOUT
 
-        response = HTTPResponse()
+        response = HTTPResponse(simplify_error_response=self.settings['simplify_error_response'])
 
         request_headers = self._http_req_apply_default_headers(
             request_headers, content_type, body)

--- a/tests.py
+++ b/tests.py
@@ -440,6 +440,18 @@ class MixinTestCase(testing.AsyncHTTPTestCase):
         self.assertFalse(response.ok)
         self.assertEqual(response.code, 400)
         self.assertEqual(response.attempts, 1)
+        self.assertEqual(
+            response.body,
+            {'message': 'Test Error', 'type': 'Test Error', 'traceback': None})
+
+    @testing.gen_test
+    def test_simpler_error_response(self):
+        self.mixin.simplify_error_response = True
+        response = yield self.mixin.http_fetch(
+            self.get_url('/error?status_code=400&message=Test%20Error'))
+        self.assertFalse(response.ok)
+        self.assertEqual(response.code, 400)
+        self.assertEqual(response.attempts, 1)
         self.assertEqual(response.body, 'Test Error')
 
     @testing.gen_test

--- a/tests.py
+++ b/tests.py
@@ -440,19 +440,19 @@ class MixinTestCase(testing.AsyncHTTPTestCase):
         self.assertFalse(response.ok)
         self.assertEqual(response.code, 400)
         self.assertEqual(response.attempts, 1)
-        self.assertEqual(
-            response.body,
-            {'message': 'Test Error', 'type': 'Test Error', 'traceback': None})
+        self.assertEqual(response.body, 'Test Error')
 
     @testing.gen_test
-    def test_simpler_error_response(self):
-        self.mixin.simplify_error_response = True
+    def test_fancier_error_response(self):
+        self.mixin.simplify_error_response = False
         response = yield self.mixin.http_fetch(
             self.get_url('/error?status_code=400&message=Test%20Error'))
         self.assertFalse(response.ok)
         self.assertEqual(response.code, 400)
         self.assertEqual(response.attempts, 1)
-        self.assertEqual(response.body, 'Test Error')
+        self.assertEqual(
+            response.body,
+            {'message': 'Test Error', 'type': 'Test Error', 'traceback': None})
 
     @testing.gen_test
     def test_error_retry(self):


### PR DESCRIPTION
This PR is a retake on https://github.com/sprockets/sprockets.mixins.http/pull/21

**The Problem**

For error responses, JSON response bodies were reduced down to their error `message`. Other attributes of the deserialized body were discarded. That prevented users from accessing other attributes in the body.

**Motivation**

As I embrace Problem Details for HTTP APIs (RFC 7807), there are cases where my software inspects other attributes of an error response's body in order to better understand and handle the error.

**A Solution**

This PR gives users the OPTION of returning a complete response body for errors.

By default, the HTTPResponse object's body is reduced down to the error `message`, which is consistent with past behavior. That seems less disruptive.

To override that behavior, you can set `self.simplify_error_response = False` in a class that uses this mixin. That instructs this mixin to return the complete response body.

This is by no means final. I welcome and encourage feedback.

**Questions**

- Should the optional override be an attribute or in the `settings` dict? I prefer the attribute. Git log explains why.
- Is it well named?
- Is it well documented?
- Would someone want to control this behavior on individual http_fetch() calls?