### PR TITLE
Address #27

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -1,6 +1,12 @@
 Version History
 ===============
 
+Next Release
+------------
+- Address `#27`_ by using the shortest appropriate timeout
+
+.. _#27: https://github.com/sprockets/sprockets.mixins.http/issues/27
+
 `2.3.0`_ Dec 9, 2019
 --------------------
 - Added an option to control response body transformation for errors, i.e. HTTP


### PR DESCRIPTION
This PR addresses #27 by using the sleeping for the minimum `Retry-After` header, the `connect_timeout`, and the `request_timeout`.  This still isn't absolutely optimal since we should be ticking down `request_timeout` for retries but ¯\_(ツ)_/¯