### PR TITLE
Pass kwargs through

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -1,6 +1,11 @@
 Version History
 ===============
 
+Next Release
+------------
+- Pass keyword parameters through to the underlying HTTPClient fetch method.
+  This enables niceties like streaming callback support
+
 `2.3.1`_ Apr 7, 2020
 --------------------
 - Address `#27`_ by using the shortest appropriate timeout

--- a/sprockets/mixins/http/__init__.py
+++ b/sprockets/mixins/http/__init__.py
@@ -272,7 +272,8 @@ class HTTPClientMixin:
                          user_agent=None,
                          validate_cert=True,
                          allow_nonstandard_methods=False,
-                         dont_retry=None):
+                         dont_retry=None,
+                         **kwargs):
         """Perform a HTTP request
 
         Will retry up to ``self.MAX_HTTP_RETRIES`` times.
@@ -304,6 +305,8 @@ class HTTPClientMixin:
             to the HTTP spec.
         :param set dont_retry: A list of status codes that will not be retried
             if an error is returned. Default: set({})
+        :param kwargs: additional keyword parameters are passed to
+            :meth:`tornado.httpclient.AsyncHTTPClient.fetch`
         :rtype: HTTPResponse
 
         """
@@ -353,7 +356,8 @@ class HTTPClientMixin:
                     max_redirects=max_redirects,
                     raise_error=False,
                     validate_cert=validate_cert,
-                    allow_nonstandard_methods=allow_nonstandard_methods)
+                    allow_nonstandard_methods=allow_nonstandard_methods,
+                    **kwargs)
             except (OSError, httpclient.HTTPError) as error:
                 response.append_exception(error)
                 LOGGER.warning(

--- a/sprockets/mixins/http/__init__.py
+++ b/sprockets/mixins/http/__init__.py
@@ -313,21 +313,29 @@ class HTTPClientMixin:
             is specified
 
         """
-        # Apply default values for non-specified arguments
-        max_http_attempts = max_http_attempts or self.MAX_HTTP_RETRIES
-        max_redirects = max_redirects or self.MAX_REDIRECTS
-        connect_timeout = connect_timeout or self.DEFAULT_CONNECT_TIMEOUT
-        request_timeout = request_timeout or self.DEFAULT_REQUEST_TIMEOUT
+        # Curry the request parameters through from our named params
+        def apply_default(val, default):
+            return default if val is None else val
+
+        # these are used elsewhere so we need them outside of kwargs
+        connect_timeout = apply_default(connect_timeout,
+                                        self.DEFAULT_CONNECT_TIMEOUT)
+        request_timeout = apply_default(request_timeout,
+                                        self.DEFAULT_REQUEST_TIMEOUT)
+        max_http_attempts = apply_default(max_http_attempts,
+                                          self.MAX_HTTP_RETRIES)
+
         kwargs.update({
             'allow_nonstandard_methods': allow_nonstandard_methods,
             'auth_password': auth_password,
             'auth_username': auth_username,
             'connect_timeout': connect_timeout,
             'follow_redirects': follow_redirects,
-            'max_redirects': max_redirects,
+            'max_redirects': apply_default(max_redirects, self.MAX_REDIRECTS),
             'method': method,
             'request_timeout': request_timeout,
-            'user_agent': user_agent or self._http_req_user_agent(),
+            'user_agent': apply_default(user_agent,
+                                        self._http_req_user_agent()),
             'validate_cert': validate_cert,
         })
 

--- a/sprockets/mixins/http/__init__.py
+++ b/sprockets/mixins/http/__init__.py
@@ -309,6 +309,9 @@ class HTTPClientMixin:
             :meth:`tornado.httpclient.AsyncHTTPClient.fetch`
         :rtype: HTTPResponse
 
+        :raises: :exc:`RuntimeError` if the ``raise_error`` keyword argument
+            is specified
+
         """
         # Apply default values for non-specified arguments
         max_http_attempts = max_http_attempts or self.MAX_HTTP_RETRIES
@@ -334,6 +337,12 @@ class HTTPClientMixin:
         # Workaround for Tornado defect.
         if hasattr(client, 'max_clients') and os.getenv('HTTP_MAX_CLIENTS'):
             client.max_clients = int(os.getenv('HTTP_MAX_CLIENTS'))
+
+        # Fail hard if someone is doing something wrong
+        if 'raise_error' in kwargs:
+            raise RuntimeError(
+                self.__class__.__name__ + '.http_fetch called with ' +
+                'raise_error')
 
         for attempt in range(0, max_http_attempts):
             LOGGER.debug('%s %s (Attempt %i of %i) %r',

--- a/sprockets/mixins/http/__init__.py
+++ b/sprockets/mixins/http/__init__.py
@@ -318,6 +318,18 @@ class HTTPClientMixin:
         max_redirects = max_redirects or self.MAX_REDIRECTS
         connect_timeout = connect_timeout or self.DEFAULT_CONNECT_TIMEOUT
         request_timeout = request_timeout or self.DEFAULT_REQUEST_TIMEOUT
+        kwargs.update({
+            'allow_nonstandard_methods': allow_nonstandard_methods,
+            'auth_password': auth_password,
+            'auth_username': auth_username,
+            'connect_timeout': connect_timeout,
+            'follow_redirects': follow_redirects,
+            'max_redirects': max_redirects,
+            'method': method,
+            'request_timeout': request_timeout,
+            'user_agent': user_agent or self._http_req_user_agent(),
+            'validate_cert': validate_cert,
+        })
 
         response = HTTPResponse(
             simplify_error_response=self.simplify_error_response)
@@ -353,19 +365,9 @@ class HTTPClientMixin:
             try:
                 resp = await client.fetch(
                     str(url),
-                    method=method,
                     headers=request_headers,
                     body=body,
-                    auth_username=auth_username,
-                    auth_password=auth_password,
-                    connect_timeout=connect_timeout,
-                    request_timeout=request_timeout,
-                    user_agent=user_agent or self._http_req_user_agent(),
-                    follow_redirects=follow_redirects,
-                    max_redirects=max_redirects,
                     raise_error=False,
-                    validate_cert=validate_cert,
-                    allow_nonstandard_methods=allow_nonstandard_methods,
                     **kwargs)
             except (OSError, httpclient.HTTPError) as error:
                 response.append_exception(error)

--- a/tests.py
+++ b/tests.py
@@ -615,3 +615,16 @@ class MixinTestCase(testing.AsyncHTTPTestCase):
         self.assertAlmostEqual(response.duration,
                                response.attempts * 0.25,
                                places=1)
+
+    @testing.gen_test
+    def test_that_kwargs_are_passed_through(self):
+        chunks = []
+
+        def streaming_callback(chunk):
+            chunks.append(chunk)
+
+        response = yield self.mixin.http_fetch(
+            self.get_url('/test'),
+            streaming_callback=streaming_callback)
+        self.assertTrue(response.ok)
+        self.assertGreater(len(chunks), 0)

--- a/tests.py
+++ b/tests.py
@@ -628,3 +628,11 @@ class MixinTestCase(testing.AsyncHTTPTestCase):
             streaming_callback=streaming_callback)
         self.assertTrue(response.ok)
         self.assertGreater(len(chunks), 0)
+
+    @testing.gen_test
+    def test_that_client_fails_if_raise_error_is_specified(self):
+        for value in (True, False, object()):
+            with self.assertRaises(RuntimeError, msg=str(value)):
+                yield self.mixin.http_fetch(
+                    self.get_url('/error?status_code=410'),
+                    raise_error=value)


### PR DESCRIPTION
It turns out that I found a need to implement streaming body response processing and found out that we cannot do it today.  Instead of adding another mimic keyword parameter, I decided to pass `**kwargs` through to the underlying fetch method.  I added special handling to explicitl reject passing `raise_error` at all since it doesn't make sense in the current context.  Since it wasn't allowed as a parameter previously, it is a non-breaking API change.

I did a little refactoring on how the params were being passed through to the underlying fetch function since we were disallowing things like `max_redirects=0`.