### PR TITLE
Rate limit 503s

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: python
 dist: xenial
 python:
 - 3.7
+- 3.8
+- 3.9
 install:
 - pip install -r requires/development.txt
 script:

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -4,6 +4,7 @@ Version History
 `Next Release`_
 ---------------
 - Fix serialization of empty request bodies.
+- Rate limit 503s as well as 423s and 429s.
 
 `2.3.3`_ Apr 8 2020
 -------------------

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -5,6 +5,7 @@ Version History
 ---------------
 - Fix serialization of empty request bodies.
 - Rate limit 503s as well as 423s and 429s.
+- Advertise & test support for Python 3.8 and 3.9.
 
 `2.3.3`_ Apr 8 2020
 -------------------

--- a/requires/testing.txt
+++ b/requires/testing.txt
@@ -1,3 +1,4 @@
+asynctest==0.13.0
 coverage==4.5.4
 codecov==2.0.15
 flake8==3.7.9

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,8 @@ setuptools.setup(
         'Natural Language :: English',
         'Operating System :: OS Independent',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: Implementation :: CPython',
         'Topic :: Software Development :: Libraries',
         'Topic :: Software Development :: Libraries :: Python Modules'

--- a/sprockets/mixins/http/__init__.py
+++ b/sprockets/mixins/http/__init__.py
@@ -392,7 +392,7 @@ class HTTPClientMixin:
                 return response
             elif resp.code in dont_retry:
                 break
-            elif resp.code in {423, 429}:
+            elif resp.code in {423, 429, 503}:
                 await self._http_resp_rate_limited(
                     resp, min(connect_timeout, request_timeout))
             elif resp.code < 500:

--- a/tests.py
+++ b/tests.py
@@ -4,6 +4,7 @@ import os
 from unittest import mock
 import uuid
 
+import asynctest
 from sprockets.mixins import http
 from tornado import httpclient, httputil, testing, web
 import umsgpack
@@ -31,10 +32,10 @@ class TestHandler(web.RequestHandler):
 
     def prepare(self):
         status_code = self.status_code()
-        if status_code == 429:
+        if status_code in {423, 429}:
             self.add_header('Retry-After',
                             self.get_argument('retry_after', '1'))
-            self.set_status(429, 'Rate Limited')
+            self.set_status(status_code, 'Rate Limited')
             self.finish()
         elif status_code in {502, 504}:
             self.set_status(status_code)
@@ -427,12 +428,22 @@ class MixinTestCase(testing.AsyncHTTPTestCase):
 
     @testing.gen_test
     def test_rate_limiting_behavior(self):
-        response = yield self.mixin.http_fetch(
-            self.get_url('/error?status_code=429'))
-        self.assertFalse(response.ok)
-        self.assertEqual(response.code, 429)
-        self.assertEqual(response.attempts, 3)
-        self.assertEqual([r.code for r in response.history], [429, 429, 429])
+        with asynctest.mock.patch(
+                'sprockets.mixins.http.asyncio') as aio_module:
+            aio_module.sleep = asynctest.CoroutineMock()
+            for rate_limit_code in {423, 429}:
+                response = yield self.mixin.http_fetch(
+                    self.get_url(f'/error?status_code={rate_limit_code}'
+                                 f'&retry_after=2'))
+                self.assertFalse(response.ok)
+                self.assertEqual(response.code, rate_limit_code)
+                self.assertEqual(response.attempts, 3)
+                self.assertEqual([r.code for r in response.history],
+                                 [rate_limit_code] * response.attempts)
+                self.assertEqual(aio_module.sleep.await_count, 3)
+                aio_module.sleep.assert_has_awaits([mock.call(2), mock.call(2),
+                                                    mock.call(2)])
+                aio_module.sleep.reset_mock()
 
     @testing.gen_test
     def test_error_response(self):

--- a/tests.py
+++ b/tests.py
@@ -32,7 +32,7 @@ class TestHandler(web.RequestHandler):
 
     def prepare(self):
         status_code = self.status_code()
-        if status_code in {423, 429}:
+        if status_code in {423, 429, 503}:
             self.add_header('Retry-After',
                             self.get_argument('retry_after', '1'))
             self.set_status(status_code, 'Rate Limited')
@@ -431,7 +431,7 @@ class MixinTestCase(testing.AsyncHTTPTestCase):
         with asynctest.mock.patch(
                 'sprockets.mixins.http.asyncio') as aio_module:
             aio_module.sleep = asynctest.CoroutineMock()
-            for rate_limit_code in {423, 429}:
+            for rate_limit_code in {423, 429, 503}:
                 response = yield self.mixin.http_fetch(
                     self.get_url(f'/error?status_code={rate_limit_code}'
                                  f'&retry_after=2'))


### PR DESCRIPTION
This PR enables our rate limiting logic for 503 responses as well as 423 & 429 which were already rate limited.