### PR TITLE
Apply rate-limit sleeps between all retries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,9 @@ python:
 install:
 - pip install -r requires/development.txt
 script:
-- nosetests
 - flake8
+- yapf -dr sprockets tests.py
+- nosetests
 after_success:
 - codecov
 - ./setup.py build_sphinx

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -4,6 +4,10 @@ Version History
 `Next Release`_
 ---------------
 - Make request retry timeout configurable
+- Apply retry sleeping to all retried attempts
+- Use an exponential backoff if ``Retry-After`` header is absent
+- Add ``retry_timeout`` parameter to
+  :meth:`~sprockets.mixins.http.HTTPClientMixin.http_fetch`
 
 `2.4.0`_ Nov 3 2020
 -------------------

--- a/requires/development.txt
+++ b/requires/development.txt
@@ -1,3 +1,4 @@
 -e .
+tox>=3.20,<4
 -r docs.txt
 -r testing.txt

--- a/requires/testing.txt
+++ b/requires/testing.txt
@@ -11,4 +11,5 @@ flake8-rst-docstrings==0.0.11
 flake8-tuple==0.4.0
 nose==1.3.7
 u-msgpack-python==2.5.2
+yapf==0.30.0
 -r installation.txt

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,9 @@
 [bdist_wheel]
 universal = 1
 
+[coverage:report]
+show_missing = 1
+
 [flake8]
 application-import-names=sprockets.mixins.http
 exclude=build,env

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,3 +20,6 @@ verbosity=2
 
 [upload_docs]
 upload-dir = build/sphinx/html
+
+[yapf]
+allow_split_before_dict_value = False

--- a/tests.py
+++ b/tests.py
@@ -475,7 +475,7 @@ class MixinTestCase(testing.AsyncHTTPTestCase):
         with asynctest.mock.patch(
                 'sprockets.mixins.http.asyncio') as aio_module:
             aio_module.sleep = asynctest.CoroutineMock()
-            for rate_limit_code in {423, 429, 500, 503}:
+            for rate_limit_code in {423, 429, 500, 502, 503}:
                 response = yield self.mixin.http_fetch(
                     self.get_url(f'/error?status_code={rate_limit_code}'
                                  f'&retry_after=2'))
@@ -498,7 +498,7 @@ class MixinTestCase(testing.AsyncHTTPTestCase):
         with asynctest.mock.patch(
                 'sprockets.mixins.http.asyncio') as aio_module:
             aio_module.sleep = asynctest.CoroutineMock()
-            for rate_limit_code in {423, 429, 500, 503}:
+            for rate_limit_code in {423, 429, 500, 502, 503}:
                 response = yield self.mixin.http_fetch(
                     self.get_url(f'/error?status_code={rate_limit_code}'),
                     max_http_attempts=max_attempts)

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,16 @@
+[tox]
+envlist = lint,py37,py38,py39
+indexserver =
+    default = https://pypi.org/simple
+toxworkdir = build/tox
+
+[testenv]
+commands =
+    python -m unittest
+deps = -rrequires/testing.txt
+use_develop = True
+
+[testenv_lint]
+commands =
+	flake8
+	yapf -dr sprockets tests.py


### PR DESCRIPTION
This PR adds an exponentially increasing sleep time between all retried requests.  It starts with the retry timeout (default 3s), and exponentiates using powers of two.  This means that the default behavior is:

- initial attempt
- sleep 3 seconds
- first retry (second attempt)
- sleep 6 seconds
- second retry (third attempt)

If any response returns a `Retry-After` header, then it is honored in place of the calculated sleep duration.

## Other changes
* ran yapf over the source code and added it into the CI script.
* added a tox file that mimics what travis is going to do -- _`tox -p` works really really well_

You can skip to only reviewing c1e8eb4 if you are only interested in the functional changes.