### PR TITLE
Fallback to iso-8859-1 when unable to decode as utf-8

### DIFF
--- a/sprockets/mixins/http/__init__.py
+++ b/sprockets/mixins/http/__init__.py
@@ -196,7 +196,10 @@ class HTTPResponse:
         elif isinstance(value, dict):
             return {self._decode(k): self._decode(v) for k, v in value.items()}
         elif isinstance(value, bytes):
-            return value.decode('utf-8')
+            try:
+                return value.decode('utf-8')
+            except UnicodeDecodeError:
+                return value.decode('iso-8859-1')
         return value
 
     def _deserialize(self):

--- a/tests.py
+++ b/tests.py
@@ -750,3 +750,19 @@ class MixinTestCase(testing.AsyncHTTPTestCase):
             request_headers={'Content-Type': 'application/json'})
         self.assertEqual(200, response.code)
         self.assertEqual([], response.body['body'])
+
+    @testing.gen_test
+    def test_iso_8859_1_response_body_decode(self):
+        mock_response = mock.Mock()
+        mock_response.code = 200
+        mock_response.body = '{"value": "í"}'.encode('iso-8859-1')
+        mock_response.headers = {'Content-Type': 'application/json'}
+
+        response = http.HTTPResponse()
+        response.append_response(mock_response)
+
+        # raw body cannot be decoded as utf-8
+        with self.assertRaises(UnicodeDecodeError):
+            response.raw.body.decode('utf-8')
+        # sprockets.mixins.http decode successfully
+        self.assertEqual(response.body, {'value': 'í'})


### PR DESCRIPTION
An API completely outside of my control is responding with iso-8859-1
encoded JSON. This change to sprockets.mixins.http attempts to handle
that.

I initially tried using chardet to determine the codec, but it incorrectly identified the content.

I unfortunately forgot to check the charset in the responses Content-Type header.