### PR TITLE
Change HTTPResponse.links to return empty list when Link header is not present

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -1,6 +1,10 @@
 Version History
 ===============
 
+Next
+----
+- Change ``HTTPResponse.links`` to return empty list when ``Link`` header is not present
+
 `2.4.1`_ Nov 30 2020
 --------------------
 - Make request retry timeout configurable

--- a/sprockets/mixins/http/__init__.py
+++ b/sprockets/mixins/http/__init__.py
@@ -152,13 +152,13 @@ class HTTPResponse:
         """
         if not self._responses:
             return None
+        links = []
         if 'Link' in self._responses[-1].headers:
-            links = []
             for l in headers.parse_link(self._responses[-1].headers['Link']):
                 link = {'target': l.target}
                 link.update({k: v for (k, v) in l.parameters})
                 links.append(link)
-            return links
+        return links
 
     @property
     def ok(self):

--- a/tests.py
+++ b/tests.py
@@ -258,7 +258,7 @@ class MixinTestCase(testing.AsyncHTTPTestCase):
             'foo': ['bar'],
             'status_code': ['200']
         })
-        self.assertIsNone(response.links)
+        self.assertEqual(response.links, [])
 
     @testing.gen_test
     def test_post(self):


### PR DESCRIPTION
- This makes it **more** convenient to iterate through links.
- This makes it **impossible** to rely upon the `links` property as indicator of the presence of a `Link` header.

The first item is arguably the more common use-case of this property. The second item can be solved by checking for `Link` in `HTTPResponse.headers`