### PR TITLE
Add hook to modify a request before each retry attempt

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,4 +1,13 @@
 API
 ---
-.. automodule:: sprockets.mixins.http
+
+.. currentmodule:: sprockets.mixins.http
+
+.. autoclass:: HTTPClientMixin
+   :member-order: bysource
    :members:
+   :private-members:
+
+.. autoclass:: HTTPResponse
+   :members:
+   :exclude-members: append_exception, append_response, finish

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -4,6 +4,9 @@ Version History
 Next
 ----
 - Change ``HTTPResponse.links`` to return empty list when ``Link`` header is not present
+- Move ``X-Retry-Attempt`` header insertion into
+  :meth:`~sprockets.mixins.http.HTTPClientMixin._http_req_modify_for_retry`
+  hook.  This is also needed for using the client with OAuth 1 servers.
 
 `2.4.1`_ Nov 30 2020
 --------------------

--- a/requires/docs.txt
+++ b/requires/docs.txt
@@ -1,3 +1,3 @@
-sphinx==2.2.0
-sphinx-rtd-theme==0.4.3
+sphinx==4.2.0
+sphinx-rtd-theme==1.0.0
 sphinxcontrib-httpdomain==1.7.0


### PR DESCRIPTION
I moved the `X-Retry-Attempt` into a hook function that returns the URL, headers, and body to be used in the next attempt.  This is necessary when you are interacting with APIs that have a single-use code included in API calls (e.g., OAuth 1 nonce).