### PR TITLE
Fix exception when correlation_id is None

### DIFF
--- a/sprockets/mixins/http/__init__.py
+++ b/sprockets/mixins/http/__init__.py
@@ -446,7 +446,7 @@ class HTTPClientMixin:
             request_headers.setdefault(
                 'Content-Type',
                 str(content_type) or str(CONTENT_TYPE_MSGPACK))
-        if hasattr(self, 'correlation_id'):
+        if hasattr(self, 'correlation_id') and self.correlation_id:
             request_headers.setdefault('Correlation-Id', self.correlation_id)
         elif hasattr(self, 'request') and \
                 self.request.headers.get('Correlation-Id'):

--- a/tests.py
+++ b/tests.py
@@ -244,6 +244,16 @@ class MixinTestCase(testing.AsyncHTTPTestCase):
         self.assertEqual(response.attempts, 3)
 
     @testing.gen_test
+    def test_correlation_id_is_none(self):
+        mixin = self.create_mixin()
+        mixin.correlation_id = None
+        response = yield mixin.http_fetch(
+            self.get_url('/error?status_code=502'))
+        self.assertFalse(response.ok)
+        self.assertEqual(response.code, 502)
+        self.assertEqual(response.attempts, 3)
+
+    @testing.gen_test
     def test_get(self):
         response = yield self.mixin.http_fetch(
             self.get_url('/test?foo=bar&status_code=200'))


### PR DESCRIPTION
Noticed this when unit testing a specific method of a Rejected consumer class. It wasn't fully instantiated, thus `self.correlation_id` was `None`.

exception: `TypeError: can only concatenate str (not "NoneType") to str`