### PR TITLE
Check explicitly for None

### DIFF
--- a/sprockets/mixins/http/__init__.py
+++ b/sprockets/mixins/http/__init__.py
@@ -452,7 +452,7 @@ class HTTPClientMixin:
             request_headers = {}
         request_headers.setdefault(
             'Accept', ', '.join([str(ct) for ct in AVAILABLE_CONTENT_TYPES]))
-        if body:
+        if body is not None:
             request_headers.setdefault(
                 'Content-Type',
                 str(content_type) or str(CONTENT_TYPE_MSGPACK))

--- a/tests.py
+++ b/tests.py
@@ -803,3 +803,18 @@ class MixinTestCase(testing.AsyncHTTPTestCase):
         self.assertEqual(response.headers['Content-Type'],
                          'bar/foo+json')
         self.assertEqual(response.body['body'], body)
+
+    @testing.gen_test
+    def test_post_without_content_type(self):
+        body = {
+            'foo': 'bar',
+        }
+        response = yield self.mixin.http_fetch(
+            self.get_url('/test'),
+            method='POST',
+            body=body,
+            request_headers={},
+        )
+        self.assertEqual(response.code, 200)
+        self.assertEqual(response.body['headers']['Content-Type'],
+                         'application/msgpack')


### PR DESCRIPTION
This fixes a bug where a key error would occur if an empty array or dict is passed in
resolves #37 