### PR TITLE
Use latest flake8-html version

### DIFF
--- a/requires/testing.txt
+++ b/requires/testing.txt
@@ -4,7 +4,7 @@ codecov==2.1.12
 flake8==4.0.1
 flake8-comprehensions==3.8.0
 flake8-deprecated==1.3
-flake8-html==0.4.1
+flake8-html==0.4.2
 flake8-import-order==0.18.1
 flake8-quotes==3.3.1
 flake8-rst-docstrings==0.2.5


### PR DESCRIPTION
The previous version was using a deprecated Jinja markup package that finally broke. This commit updates to the latesst version of flake8-html which resolves the broken dependency.